### PR TITLE
Resolved unsafe random source usage

### DIFF
--- a/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/ai/goal/ImprovedCrossbowGoal.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/ai/goal/ImprovedCrossbowGoal.java
@@ -279,7 +279,7 @@ public class ImprovedCrossbowGoal<T extends PathfinderMob & RangedAttackMob & Cr
 
 	private void performShooting(Level world, T shooter, Vec3 targetPos, InteractionHand hand, ItemStack weapon) {
 		List<ItemStack> projectiles = CrossbowItem.getChargedProjectiles(weapon);
-		float[] soundPitches = CrossbowItem.getShotPitches(world.getRandom());
+		float[] soundPitches = CrossbowItem.getShotPitches(this.mob.getRandom());
 
 		for (int i = 0; i < Math.min(projectiles.size(), 3); i++) {
 			ItemStack projectileStack = projectiles.get(i);

--- a/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/monster/Griefer.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/monster/Griefer.java
@@ -206,7 +206,7 @@ public class Griefer extends AbstractIllager implements RangedAttackMob {
 	public SpawnGroupData finalizeSpawn(ServerLevelAccessor worldIn, DifficultyInstance difficultyIn, MobSpawnType reason, @Nullable SpawnGroupData spawnDataIn, @Nullable CompoundTag dataTag) {
 		super.finalizeSpawn(worldIn, difficultyIn, reason, spawnDataIn, dataTag);
 		this.populateDefaultEquipmentSlots(difficultyIn);
-		this.creeperSporeStacks = 3 + random.nextInt(3);
+		this.creeperSporeStacks = 3 + this.random.nextInt(3);
 		return spawnDataIn;
 	}
 
@@ -241,7 +241,7 @@ public class Griefer extends AbstractIllager implements RangedAttackMob {
 			double d3 = target.getZ() - this.getZ();
 			float f = Mth.sqrt((float) (d1 * d1 + d3 * d3)) * 0.2F;
 			creeperSpores.shoot(d1, d2 + (double) f, d3, 1.6F, 12.0F);
-			creeperSpores.setCloudSize(creeperSpores.level.random.nextInt(50) == 0 ? 0 : 1 + creeperSpores.level.random.nextInt(3));
+			creeperSpores.setCloudSize(this.random.nextInt(50) == 0 ? 0 : 1 + this.random.nextInt(3));
 			this.swing(getUsedItemHand());
 			this.playSound(SRSounds.ENTITY_CREEPER_SPORES_THROW.get(), 1.0F, 1.0F / (this.getRandom().nextFloat() * 0.4F + 0.8F));
 			this.level.addFreshEntity(creeperSpores);
@@ -309,7 +309,7 @@ public class Griefer extends AbstractIllager implements RangedAttackMob {
 		@Override
 		protected void checkAndPerformAttack(LivingEntity enemy, double distToEnemySqr) {
 			double distance = this.getAttackReachSqr(enemy);
-			int i = griefer.level.random.nextInt(3);
+			int i = griefer.getRandom().nextInt(3);
 			if (distToEnemySqr <= distance && this.ticksUntilNextAttack <= 0) {
 				this.ticksUntilNextAttack = 60;
 				switch (i) {

--- a/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/monster/SkeletonVillager.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/monster/SkeletonVillager.java
@@ -129,10 +129,9 @@ public class SkeletonVillager extends AbstractSkeleton implements CrossbowAttack
 	@Nullable
 	@Override
 	public SpawnGroupData finalizeSpawn(ServerLevelAccessor worldIn, DifficultyInstance difficultyIn, MobSpawnType reason, @Nullable SpawnGroupData spawnDataIn, @Nullable CompoundTag dataTag) {
-		RandomSource random = worldIn.getRandom();
-		this.populateDefaultEquipmentSlots(random, difficultyIn);
-		this.populateDefaultEquipmentEnchantments(random, difficultyIn);
-		if (worldIn.getRandom().nextInt(100) == 0) {
+		this.populateDefaultEquipmentSlots(this.getRandom(), difficultyIn);
+		this.populateDefaultEquipmentEnchantments(this.getRandom(), difficultyIn);
+		if (this.getRandom().nextInt(100) == 0) {
 			Spider spider = EntityType.SPIDER.create(this.level);
 			if (spider != null) {
 				spider.copyPosition(this);

--- a/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/monster/Trickster.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/monster/Trickster.java
@@ -133,7 +133,7 @@ public class Trickster extends SpellcasterIllager implements TracksHits {
 	public void tick() {
 		super.tick();
 		//Rune particles at hands
-		if (level.random.nextInt(14) == 0 && this.isCastingSpell()) {
+		if (this.random.nextInt(14) == 0 && this.isCastingSpell()) {
 			//Handles entity rotation
 			float f = this.yBodyRot * ((float) Math.PI / 180F) + Mth.cos((float) this.tickCount * 0.6662F) * 0.25F;
 			float f1 = Mth.cos(f);
@@ -210,8 +210,8 @@ public class Trickster extends SpellcasterIllager implements TracksHits {
 					this.level.playSound(null, oldPos, SRSounds.GENERIC_PUFF_OF_SMOKE.get(), this.getSoundSource(), 10.0F, 1.0F);
 					this.level.playSound(null, this.blockPosition(), SRSounds.GENERIC_PUFF_OF_SMOKE.get(), this.getSoundSource(), 10.0F, 1.0F);
 					this.level.playSound(null, oldPos, SRSounds.ENTITY_TRICKSTER_LAUGH.get(), SoundSource.HOSTILE, 1.0F, 1.0F);
-					ConfusionBolt.spawnGaussianParticles(this.level, oldBox, SREvents.POOF_KEY, 50);
-					ConfusionBolt.spawnGaussianParticles(this.level, this.getBoundingBox().inflate(0.5D), SREvents.POOF_KEY, 50);
+					ConfusionBolt.spawnGaussianParticles(this.level, this.random, oldBox, SREvents.POOF_KEY, 50);
+					ConfusionBolt.spawnGaussianParticles(this.level, this.random, this.getBoundingBox().inflate(0.5D), SREvents.POOF_KEY, 50);
 					if (ForgeEventFactory.getMobGriefingEvent(this.level, this)) {
 						BlockPos.MutableBlockPos searchPos = new BlockPos.MutableBlockPos();
 						for (int x = oldPos.getX() - 2; x <= oldPos.getX() + 2; x++) {

--- a/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/projectile/ConfusionBolt.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/common/entity/projectile/ConfusionBolt.java
@@ -67,7 +67,7 @@ public class ConfusionBolt extends ThrowableProjectile {
 		Vec3 deltaMovement = this.getDeltaMovement();
 		super.tick();
 		this.setDeltaMovement(deltaMovement); //Undoes tampering by superclass
-		spawnGaussianParticles(this.level, this.getBoundingBox(), SRParticleTypes.CONFUSION_BOLT.getId().toString(), 5);
+		spawnGaussianParticles(this.level, this.random, this.getBoundingBox(), SRParticleTypes.CONFUSION_BOLT.getId().toString(), 5);
 		this.entityData.set(TICKS_TILL_REMOVE, this.entityData.get(TICKS_TILL_REMOVE) - 1);
 		if (this.entityData.get(TICKS_TILL_REMOVE) <= 0)
 			this.discard();
@@ -82,8 +82,7 @@ public class ConfusionBolt extends ThrowableProjectile {
 		}
 	}
 
-	public static void spawnGaussianParticles(Level world, AABB box, String name, int loops) {
-		RandomSource random = world.getRandom();
+	public static void spawnGaussianParticles(Level world, RandomSource random, AABB box, String name, int loops) {
 		if (!world.isClientSide) {
 			for (int i = 0; i < loops; i++) {
 				double x = box.min(Direction.Axis.X) + ((0.5 + (random.nextGaussian() * 0.25)) * box.getXsize());
@@ -97,7 +96,7 @@ public class ConfusionBolt extends ThrowableProjectile {
 	@Override
 	protected void onHit(HitResult result) {
 		this.playSound(SRSounds.GENERIC_PUFF_OF_SMOKE.get(), 5.0F, 1.0F);
-		spawnGaussianParticles(this.level, this.getBoundingBox().inflate(0.5D), SREvents.POOF_KEY, 25);
+		spawnGaussianParticles(this.level, this.random, this.getBoundingBox().inflate(0.5D), SREvents.POOF_KEY, 25);
 		super.onHit(result);
 		this.discard();
 	}
@@ -118,7 +117,7 @@ public class ConfusionBolt extends ThrowableProjectile {
 				livingEntity.addEffect(new MobEffectInstance(MobEffects.BLINDNESS, 30));
 			}
 			livingEntity.playSound(SRSounds.GENERIC_PUFF_OF_SMOKE.get(), 5.0F, 1.0F);
-			spawnGaussianParticles(this.level, livingEntity.getBoundingBox().inflate(0.5D), SREvents.POOF_KEY, 25);
+			spawnGaussianParticles(this.level, this.random, livingEntity.getBoundingBox().inflate(0.5D), SREvents.POOF_KEY, 25);
 			if (owner instanceof TracksHits)
 				((TracksHits) owner).onTrackedHit(this, entity);
 		}

--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/mixin/PillagerMixin.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/mixin/PillagerMixin.java
@@ -26,7 +26,7 @@ public abstract class PillagerMixin extends AbstractIllager implements CrossbowA
 
 	@Inject(method = "finalizeSpawn", at = @At(value = "HEAD"))
 	public void addFirework(ServerLevelAccessor world, DifficultyInstance difficulty, MobSpawnType reason, SpawnGroupData data, CompoundTag nbt, CallbackInfoReturnable<SpawnGroupData> info) {
-		if (this.level.random.nextInt(100) == 0) {
+		if (this.getRandom().nextInt(100) == 0) {
 			this.setItemSlot(EquipmentSlot.OFFHAND, SREvents.createRocket(this.getRandom()));
 			this.startUsingItem(InteractionHand.OFF_HAND);
 			this.setDropChance(EquipmentSlot.OFFHAND, 2.0F);

--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
@@ -142,14 +142,14 @@ public class SREvents {
 			Player player = event.getEntity();
 			CompoundTag persistentData = target.getPersistentData();
 			if (!persistentData.getBoolean(POISON_TAG)) {
-				if (target.level.random.nextDouble() < SRConfig.COMMON.poisonPotatoChance.get()) {
+				if (target.level.getRandom().nextDouble() < SRConfig.COMMON.poisonPotatoChance.get()) {
 					target.playSound(SoundEvents.GENERIC_EAT, 0.5f, 0.25f);
 					persistentData.putBoolean(POISON_TAG, true);
 					if (SRConfig.COMMON.poisonPotatoEffect.get()) {
 						((LivingEntity) target).addEffect(new MobEffectInstance(MobEffects.POISON, 200));
 					}
 				} else {
-					target.playSound(SoundEvents.GENERIC_EAT, 0.5f, 0.5f + target.level.random.nextFloat() / 2);
+					target.playSound(SoundEvents.GENERIC_EAT, 0.5f, 0.5f + target.level.getRandom().nextFloat() / 2);
 				}
 				if (!player.isCreative()) stack.shrink(1);
 				event.setCancellationResult(InteractionResult.sidedSuccess(event.getLevel().isClientSide()));

--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
@@ -142,14 +142,14 @@ public class SREvents {
 			Player player = event.getEntity();
 			CompoundTag persistentData = target.getPersistentData();
 			if (!persistentData.getBoolean(POISON_TAG)) {
-				if (target.level.getRandom().nextDouble() < SRConfig.COMMON.poisonPotatoChance.get()) {
+				if (target.level.random.nextDouble() < SRConfig.COMMON.poisonPotatoChance.get()) {
 					target.playSound(SoundEvents.GENERIC_EAT, 0.5f, 0.25f);
 					persistentData.putBoolean(POISON_TAG, true);
 					if (SRConfig.COMMON.poisonPotatoEffect.get()) {
 						((LivingEntity) target).addEffect(new MobEffectInstance(MobEffects.POISON, 200));
 					}
 				} else {
-					target.playSound(SoundEvents.GENERIC_EAT, 0.5f, 0.5f + target.level.getRandom().nextFloat() / 2);
+					target.playSound(SoundEvents.GENERIC_EAT, 0.5f, 0.5f + target.level.random.nextFloat() / 2);
 				}
 				if (!player.isCreative()) stack.shrink(1);
 				event.setCancellationResult(InteractionResult.sidedSuccess(event.getLevel().isClientSide()));


### PR DESCRIPTION
Fixes https://github.com/team-abnormals/savage-and-ravage/issues/119

These are the randomsources that are not safe for threaded code that I can find. Remember, if given a living entity or are inside an entity's class, always use the entity's randomsource so you don't crash vanilla's usage of the level's randomsource that's running on the server thread.