### PR TITLE
Tag compatibility for creepie spawning and disabling creeper explosions

### DIFF
--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/data/server/tags/SREntityTypeTagsProvider.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/data/server/tags/SREntityTypeTagsProvider.java
@@ -24,5 +24,6 @@ public class SREntityTypeTagsProvider extends EntityTypeTagsProvider {
 		this.tag(EntityTypeTags.FREEZE_IMMUNE_ENTITY_TYPES).add(SREntityTypes.ICEOLOGER.get());
 
 		this.tag(SREntityTypeTags.CREEPER_IMMUNE).add(EntityType.PAINTING, EntityType.ITEM_FRAME, EntityType.GLOW_ITEM_FRAME, EntityType.FALLING_BLOCK, EntityType.LEASH_KNOT, EntityType.ARMOR_STAND);
+		this.tag(SREntityTypeTags.CREEPER).add(EntityType.CREEPER);
 	}
 }

--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
@@ -191,7 +191,7 @@ public class SREvents {
 		Level world = event.getLevel();
 		Explosion explosion = event.getExplosion();
 		LivingEntity sourceEntity = explosion.getSourceMob();
-		boolean isCreeper = sourceEntity != null && sourceEntity.getType() == EntityType.CREEPER;
+		boolean isCreeper = sourceEntity != null && sourceEntity.getType().is(SREntityTypeTags.CREEPER);
 		boolean isCreepie = sourceEntity != null && sourceEntity.getType() == SREntityTypes.CREEPIE.get();
 		if (isCreeper) {
 			if (!SRConfig.COMMON.creeperExplosionsDestroyBlocks.get())

--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/other/tags/SREntityTypeTags.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/other/tags/SREntityTypeTags.java
@@ -8,6 +8,7 @@ import net.minecraft.world.entity.EntityType;
 public class SREntityTypeTags {
 	public static final TagKey<EntityType<?>> CREEPER_IMMUNE = entityTypeTag("creeper_immune");
 
+	public static final TagKey<EntityType<?>> CREEPER = entityTypeTag("creeper");
 	private static TagKey<EntityType<?>> entityTypeTag(String name) {
 		return TagUtil.entityTypeTag(SavageAndRavage.MOD_ID, name);
 	}


### PR DESCRIPTION
- three lines of new code, zero impact to existing features
- better configuration options for pack creators (creeper overhaul in particular, which I ran into when making a pack)

If approved, I'll quickly backport to 1.18 and maybe look into automatic mod compat.

Are there any other S&R changes to creeper functionality that should be covered by this?