### PR TITLE
Add config option for improved Illager AI

### DIFF
--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/SRConfig.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/SRConfig.java
@@ -16,6 +16,7 @@ public class SRConfig {
 		public final BooleanValue creepieExplosionsDestroyBlocks;
 		public final BooleanValue evokersUseTotems;
 		public final BooleanValue reducedVexHealth;
+		public final BooleanValue improvedIllagerBehavior;
 		@ConfigKey("no_bad_omen_on_death")
 		public final BooleanValue noBadOmenOnDeath;
 		public final BooleanValue poisonPotatoCompat;
@@ -38,6 +39,9 @@ public class SRConfig {
 					.comment("When killed by projectiles, evokers use a totem of undying", "This restores 2 health and gives them a projectile-proof shield for 30 seconds", "When their shield runs out, evokers cannot use totems for another 90 seconds")
 					.define("Evokers use totems", true);
 			reducedVexHealth = builder.define("Vex health is reduced to 2", true);
+			improvedIllagerBehavior = builder
+					.comment("Replaces the vanilla AI of Illagers with the improved AI. Disabling it will revert to the vanilla AI, which can be useful for mob or experience farms that depend on specific Illager behavior")
+					.define("Illagers use the new improved AI", true);
 			builder.pop();
 			builder.pop();
 

--- a/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
+++ b/src/main/java/com/teamabnormals/savage_and_ravage/core/other/SREvents.java
@@ -101,7 +101,7 @@ public class SREvents {
 					Creepie creepie = ((Creepie) e);
 					return creepie.getOwnerId() == null || creepie.getOwner() instanceof Griefer;
 				}));
-			} else if (mob instanceof Pillager pillager) {
+			} else if (mob instanceof Pillager pillager && SRConfig.COMMON.improvedIllagerBehavior.get()) {
 				mob.goalSelector.availableGoals.stream().map(it -> it.goal).filter(it -> it instanceof RangedCrossbowAttackGoal<?>).findFirst().ifPresent(goal -> {
 					mob.goalSelector.removeGoal(goal);
 					mob.goalSelector.addGoal(3, new ImprovedCrossbowGoal<>(pillager, 1.0D, 8.0F, 5.0D));


### PR DESCRIPTION
It would be great to have an option to disable the changes to the Illager/Pillager behavior as they can break certain mob and xp farm designs. Like this it can be easily switched on/off in case the player wants to do something else besides standing in a farm.